### PR TITLE
chore(structure): exclude Android platform

### DIFF
--- a/Runtime/Tilia.SDK.SteamVR.Unity.Runtime.asmdef
+++ b/Runtime/Tilia.SDK.SteamVR.Unity.Runtime.asmdef
@@ -7,7 +7,9 @@
     ],
     "optionalUnityReferences": [],
     "includePlatforms": [],
-    "excludePlatforms": [],
+    "excludePlatforms": [
+        "Android"
+    ],
     "allowUnsafeCode": false,
     "overrideReferences": true,
     "precompiledReferences": [


### PR DESCRIPTION
As SteamVR and its plugin is not available on android platform,
exclude it from the assembly definition.