### PR TITLE
feat(Malimbe): remove malimbe dependency

### DIFF
--- a/Documentation/API/Input/SteamVRBehaviourBooleanAction.md
+++ b/Documentation/API/Input/SteamVRBehaviourBooleanAction.md
@@ -7,7 +7,10 @@ Listens for the linked boolean behavior and emits the appropriate action.
 * [Inheritance]
 * [Namespace]
 * [Syntax]
+* [Properties]
+  * [LinkedBooleanBehaviour]
 * [Methods]
+  * [ClearLinkedBooleanBehaviour()]
   * [Listener(SteamVR\_Behaviour\_Boolean, SteamVR\_Input\_Sources, Boolean)]
   * [OnAfterLinkedBooleanBehaviourChange()]
   * [OnBeforeLinkedBooleanBehaviourChange()]
@@ -33,7 +36,29 @@ Listens for the linked boolean behavior and emits the appropriate action.
 public class SteamVRBehaviourBooleanAction : BooleanAction
 ```
 
+### Properties
+
+#### LinkedBooleanBehaviour
+
+The SteamVR Boolean Behavior to link this action to.
+
+##### Declaration
+
+```
+public SteamVR_Behaviour_Boolean LinkedBooleanBehaviour { get; set; }
+```
+
 ### Methods
+
+#### ClearLinkedBooleanBehaviour()
+
+Clears [LinkedBooleanBehaviour].
+
+##### Declaration
+
+```
+public virtual void ClearLinkedBooleanBehaviour()
+```
 
 #### Listener(SteamVR\_Behaviour\_Boolean, SteamVR\_Input\_Sources, Boolean)
 
@@ -55,7 +80,7 @@ protected virtual void Listener(SteamVR_Behaviour_Boolean action, SteamVR_Input_
 
 #### OnAfterLinkedBooleanBehaviourChange()
 
-Called after Tilia.SDK.SteamVR.Input.SteamVRBehaviourBooleanAction.LinkedBooleanBehaviour has been changed.
+Called after [LinkedBooleanBehaviour] has been changed.
 
 ##### Declaration
 
@@ -65,7 +90,7 @@ protected virtual void OnAfterLinkedBooleanBehaviourChange()
 
 #### OnBeforeLinkedBooleanBehaviourChange()
 
-Called before Tilia.SDK.SteamVR.Input.SteamVRBehaviourBooleanAction.LinkedBooleanBehaviour has been changed.
+Called before [LinkedBooleanBehaviour] has been changed.
 
 ##### Declaration
 
@@ -91,7 +116,7 @@ protected override void OnEnable()
 
 #### RegisterListeners()
 
-Registers the listeners against the Tilia.SDK.SteamVR.Input.SteamVRBehaviourBooleanAction.LinkedBooleanBehaviour.
+Registers the listeners against the [LinkedBooleanBehaviour].
 
 ##### Declaration
 
@@ -101,7 +126,7 @@ protected virtual void RegisterListeners()
 
 #### UnregisterListeners()
 
-Unregisters the listeners against the Tilia.SDK.SteamVR.Input.SteamVRBehaviourBooleanAction.LinkedBooleanBehaviour.
+Unregisters the listeners against the [LinkedBooleanBehaviour].
 
 ##### Declaration
 
@@ -110,10 +135,18 @@ protected virtual void UnregisterListeners()
 ```
 
 [Tilia.SDK.SteamVR.Input]: README.md
+[LinkedBooleanBehaviour]: SteamVRBehaviourBooleanAction.md#LinkedBooleanBehaviour
+[LinkedBooleanBehaviour]: SteamVRBehaviourBooleanAction.md#LinkedBooleanBehaviour
+[LinkedBooleanBehaviour]: SteamVRBehaviourBooleanAction.md#LinkedBooleanBehaviour
+[LinkedBooleanBehaviour]: SteamVRBehaviourBooleanAction.md#LinkedBooleanBehaviour
+[LinkedBooleanBehaviour]: SteamVRBehaviourBooleanAction.md#LinkedBooleanBehaviour
 [Inheritance]: #Inheritance
 [Namespace]: #Namespace
 [Syntax]: #Syntax
+[Properties]: #Properties
+[LinkedBooleanBehaviour]: #LinkedBooleanBehaviour
 [Methods]: #Methods
+[ClearLinkedBooleanBehaviour()]: #ClearLinkedBooleanBehaviour
 [Listener(SteamVR\_Behaviour\_Boolean, SteamVR\_Input\_Sources, Boolean)]: #ListenerSteamVR\_Behaviour\_Boolean-SteamVR\_Input\_Sources-Boolean
 [OnAfterLinkedBooleanBehaviourChange()]: #OnAfterLinkedBooleanBehaviourChange
 [OnBeforeLinkedBooleanBehaviourChange()]: #OnBeforeLinkedBooleanBehaviourChange

--- a/Documentation/API/Input/SteamVRBehaviourFloatAction.md
+++ b/Documentation/API/Input/SteamVRBehaviourFloatAction.md
@@ -7,7 +7,11 @@ Listens for the linked single behavior and emits the appropriate action.
 * [Inheritance]
 * [Namespace]
 * [Syntax]
+* [Properties]
+  * [AxisValue]
+  * [LinkedSingleBehaviour]
 * [Methods]
+  * [ClearLinkedSingleBehaviour()]
   * [Listener(SteamVR\_Behaviour\_Single, SteamVR\_Input\_Sources, Single, Single)]
   * [OnAfterLinkedSingleBehaviourChange()]
   * [OnBeforeLinkedSingleBehaviourChange()]
@@ -33,7 +37,39 @@ Listens for the linked single behavior and emits the appropriate action.
 public class SteamVRBehaviourFloatAction : FloatAction
 ```
 
+### Properties
+
+#### AxisValue
+
+The value to receive from the axis data.
+
+##### Declaration
+
+```
+public SteamVRBehaviourFloatAction.ValueType AxisValue { get; set; }
+```
+
+#### LinkedSingleBehaviour
+
+The SteamVR Single Behavior to link this action to.
+
+##### Declaration
+
+```
+public SteamVR_Behaviour_Single LinkedSingleBehaviour { get; set; }
+```
+
 ### Methods
+
+#### ClearLinkedSingleBehaviour()
+
+Clears [LinkedSingleBehaviour].
+
+##### Declaration
+
+```
+public virtual void ClearLinkedSingleBehaviour()
+```
 
 #### Listener(SteamVR\_Behaviour\_Single, SteamVR\_Input\_Sources, Single, Single)
 
@@ -56,7 +92,7 @@ protected virtual void Listener(SteamVR_Behaviour_Single action, SteamVR_Input_S
 
 #### OnAfterLinkedSingleBehaviourChange()
 
-Called after Tilia.SDK.SteamVR.Input.SteamVRBehaviourFloatAction.LinkedSingleBehaviour has been changed.
+Called after [LinkedSingleBehaviour] has been changed.
 
 ##### Declaration
 
@@ -66,7 +102,7 @@ protected virtual void OnAfterLinkedSingleBehaviourChange()
 
 #### OnBeforeLinkedSingleBehaviourChange()
 
-Called before Tilia.SDK.SteamVR.Input.SteamVRBehaviourFloatAction.LinkedSingleBehaviour has been changed.
+Called before [LinkedSingleBehaviour] has been changed.
 
 ##### Declaration
 
@@ -92,7 +128,7 @@ protected override void OnEnable()
 
 #### RegisterListeners()
 
-Registers the listeners against the Tilia.SDK.SteamVR.Input.SteamVRBehaviourFloatAction.LinkedSingleBehaviour.
+Registers the listeners against the [LinkedSingleBehaviour].
 
 ##### Declaration
 
@@ -102,7 +138,7 @@ protected virtual void RegisterListeners()
 
 #### UnregisterListeners()
 
-Unregisters the listeners against the Tilia.SDK.SteamVR.Input.SteamVRBehaviourFloatAction.LinkedSingleBehaviour.
+Unregisters the listeners against the [LinkedSingleBehaviour].
 
 ##### Declaration
 
@@ -111,10 +147,20 @@ protected virtual void UnregisterListeners()
 ```
 
 [Tilia.SDK.SteamVR.Input]: README.md
+[SteamVRBehaviourFloatAction.ValueType]: SteamVRBehaviourFloatAction.ValueType.md
+[LinkedSingleBehaviour]: SteamVRBehaviourFloatAction.md#LinkedSingleBehaviour
+[LinkedSingleBehaviour]: SteamVRBehaviourFloatAction.md#LinkedSingleBehaviour
+[LinkedSingleBehaviour]: SteamVRBehaviourFloatAction.md#LinkedSingleBehaviour
+[LinkedSingleBehaviour]: SteamVRBehaviourFloatAction.md#LinkedSingleBehaviour
+[LinkedSingleBehaviour]: SteamVRBehaviourFloatAction.md#LinkedSingleBehaviour
 [Inheritance]: #Inheritance
 [Namespace]: #Namespace
 [Syntax]: #Syntax
+[Properties]: #Properties
+[AxisValue]: #AxisValue
+[LinkedSingleBehaviour]: #LinkedSingleBehaviour
 [Methods]: #Methods
+[ClearLinkedSingleBehaviour()]: #ClearLinkedSingleBehaviour
 [Listener(SteamVR\_Behaviour\_Single, SteamVR\_Input\_Sources, Single, Single)]: #ListenerSteamVR\_Behaviour\_Single-SteamVR\_Input\_Sources-Single-Single
 [OnAfterLinkedSingleBehaviourChange()]: #OnAfterLinkedSingleBehaviourChange
 [OnBeforeLinkedSingleBehaviourChange()]: #OnBeforeLinkedSingleBehaviourChange

--- a/Documentation/API/Input/SteamVRBehaviourVector2Action.md
+++ b/Documentation/API/Input/SteamVRBehaviourVector2Action.md
@@ -7,7 +7,11 @@ Listens for the linked Vector2 behavior and emits the appropriate action.
 * [Inheritance]
 * [Namespace]
 * [Syntax]
+* [Properties]
+  * [AxisValue]
+  * [LinkedVector2Behaviour]
 * [Methods]
+  * [ClearLinkedVector2Behaviour()]
   * [Listener(SteamVR\_Behaviour\_Vector2, SteamVR\_Input\_Sources, Vector2, Vector2)]
   * [OnAfterLinkedVector2BehaviourChange()]
   * [OnBeforeLinkedVector2BehaviourChange()]
@@ -33,7 +37,39 @@ Listens for the linked Vector2 behavior and emits the appropriate action.
 public class SteamVRBehaviourVector2Action : Vector2Action
 ```
 
+### Properties
+
+#### AxisValue
+
+The value to receive from the axis data.
+
+##### Declaration
+
+```
+public SteamVRBehaviourVector2Action.ValueType AxisValue { get; set; }
+```
+
+#### LinkedVector2Behaviour
+
+The SteamVR Vector2 Behavior to link this action to.
+
+##### Declaration
+
+```
+public SteamVR_Behaviour_Vector2 LinkedVector2Behaviour { get; set; }
+```
+
 ### Methods
+
+#### ClearLinkedVector2Behaviour()
+
+Clears [LinkedVector2Behaviour].
+
+##### Declaration
+
+```
+public virtual void ClearLinkedVector2Behaviour()
+```
 
 #### Listener(SteamVR\_Behaviour\_Vector2, SteamVR\_Input\_Sources, Vector2, Vector2)
 
@@ -56,7 +92,7 @@ protected virtual void Listener(SteamVR_Behaviour_Vector2 action, SteamVR_Input_
 
 #### OnAfterLinkedVector2BehaviourChange()
 
-Called after Tilia.SDK.SteamVR.Input.SteamVRBehaviourVector2Action.LinkedVector2Behaviour has been changed.
+Called after [LinkedVector2Behaviour] has been changed.
 
 ##### Declaration
 
@@ -66,7 +102,7 @@ protected virtual void OnAfterLinkedVector2BehaviourChange()
 
 #### OnBeforeLinkedVector2BehaviourChange()
 
-Called before Tilia.SDK.SteamVR.Input.SteamVRBehaviourVector2Action.LinkedVector2Behaviour has been changed.
+Called before [LinkedVector2Behaviour] has been changed.
 
 ##### Declaration
 
@@ -92,7 +128,7 @@ protected override void OnEnable()
 
 #### RegisterListeners()
 
-Registers the listeners against the Tilia.SDK.SteamVR.Input.SteamVRBehaviourVector2Action.LinkedVector2Behaviour.
+Registers the listeners against the [LinkedVector2Behaviour].
 
 ##### Declaration
 
@@ -102,7 +138,7 @@ protected virtual void RegisterListeners()
 
 #### UnregisterListeners()
 
-Unregisters the listeners against the Tilia.SDK.SteamVR.Input.SteamVRBehaviourVector2Action.LinkedVector2Behaviour.
+Unregisters the listeners against the [LinkedVector2Behaviour].
 
 ##### Declaration
 
@@ -111,10 +147,20 @@ protected virtual void UnregisterListeners()
 ```
 
 [Tilia.SDK.SteamVR.Input]: README.md
+[SteamVRBehaviourVector2Action.ValueType]: SteamVRBehaviourVector2Action.ValueType.md
+[LinkedVector2Behaviour]: SteamVRBehaviourVector2Action.md#LinkedVector2Behaviour
+[LinkedVector2Behaviour]: SteamVRBehaviourVector2Action.md#LinkedVector2Behaviour
+[LinkedVector2Behaviour]: SteamVRBehaviourVector2Action.md#LinkedVector2Behaviour
+[LinkedVector2Behaviour]: SteamVRBehaviourVector2Action.md#LinkedVector2Behaviour
+[LinkedVector2Behaviour]: SteamVRBehaviourVector2Action.md#LinkedVector2Behaviour
 [Inheritance]: #Inheritance
 [Namespace]: #Namespace
 [Syntax]: #Syntax
+[Properties]: #Properties
+[AxisValue]: #AxisValue
+[LinkedVector2Behaviour]: #LinkedVector2Behaviour
 [Methods]: #Methods
+[ClearLinkedVector2Behaviour()]: #ClearLinkedVector2Behaviour
 [Listener(SteamVR\_Behaviour\_Vector2, SteamVR\_Input\_Sources, Vector2, Vector2)]: #ListenerSteamVR\_Behaviour\_Vector2-SteamVR\_Input\_Sources-Vector2-Vector2
 [OnAfterLinkedVector2BehaviourChange()]: #OnAfterLinkedVector2BehaviourChange
 [OnBeforeLinkedVector2BehaviourChange()]: #OnBeforeLinkedVector2BehaviourChange

--- a/Documentation/API/Input/SteamVRBehaviourVector3Action.md
+++ b/Documentation/API/Input/SteamVRBehaviourVector3Action.md
@@ -7,7 +7,11 @@ Listens for the linked Vector3 behavior and emits the appropriate action.
 * [Inheritance]
 * [Namespace]
 * [Syntax]
+* [Properties]
+  * [AxisValue]
+  * [LinkedVector3Behaviour]
 * [Methods]
+  * [ClearLinkedVector3Behaviour()]
   * [Listener(SteamVR\_Behaviour\_Vector3, SteamVR\_Input\_Sources, Vector3, Vector3)]
   * [OnAfterLinkedVector3BehaviourChange()]
   * [OnBeforeLinkedVector3BehaviourChange()]
@@ -33,7 +37,39 @@ Listens for the linked Vector3 behavior and emits the appropriate action.
 public class SteamVRBehaviourVector3Action : Vector3Action
 ```
 
+### Properties
+
+#### AxisValue
+
+The value to receive from the axis data.
+
+##### Declaration
+
+```
+public SteamVRBehaviourVector3Action.ValueType AxisValue { get; set; }
+```
+
+#### LinkedVector3Behaviour
+
+The SteamVR Vector3 Behavior to link this action to.
+
+##### Declaration
+
+```
+public SteamVR_Behaviour_Vector3 LinkedVector3Behaviour { get; set; }
+```
+
 ### Methods
+
+#### ClearLinkedVector3Behaviour()
+
+Clears [LinkedVector3Behaviour].
+
+##### Declaration
+
+```
+public virtual void ClearLinkedVector3Behaviour()
+```
 
 #### Listener(SteamVR\_Behaviour\_Vector3, SteamVR\_Input\_Sources, Vector3, Vector3)
 
@@ -56,7 +92,7 @@ protected virtual void Listener(SteamVR_Behaviour_Vector3 action, SteamVR_Input_
 
 #### OnAfterLinkedVector3BehaviourChange()
 
-Called after Tilia.SDK.SteamVR.Input.SteamVRBehaviourVector3Action.LinkedVector3Behaviour has been changed.
+Called after [LinkedVector3Behaviour] has been changed.
 
 ##### Declaration
 
@@ -66,7 +102,7 @@ protected virtual void OnAfterLinkedVector3BehaviourChange()
 
 #### OnBeforeLinkedVector3BehaviourChange()
 
-Called before Tilia.SDK.SteamVR.Input.SteamVRBehaviourVector3Action.LinkedVector3Behaviour has been changed.
+Called before [LinkedVector3Behaviour] has been changed.
 
 ##### Declaration
 
@@ -92,7 +128,7 @@ protected override void OnEnable()
 
 #### RegisterListeners()
 
-Registers the listeners against the Tilia.SDK.SteamVR.Input.SteamVRBehaviourVector3Action.LinkedVector3Behaviour.
+Registers the listeners against the [LinkedVector3Behaviour].
 
 ##### Declaration
 
@@ -102,7 +138,7 @@ protected virtual void RegisterListeners()
 
 #### UnregisterListeners()
 
-Unregisters the listeners against the Tilia.SDK.SteamVR.Input.SteamVRBehaviourVector3Action.LinkedVector3Behaviour.
+Unregisters the listeners against the [LinkedVector3Behaviour].
 
 ##### Declaration
 
@@ -111,10 +147,20 @@ protected virtual void UnregisterListeners()
 ```
 
 [Tilia.SDK.SteamVR.Input]: README.md
+[SteamVRBehaviourVector3Action.ValueType]: SteamVRBehaviourVector3Action.ValueType.md
+[LinkedVector3Behaviour]: SteamVRBehaviourVector3Action.md#LinkedVector3Behaviour
+[LinkedVector3Behaviour]: SteamVRBehaviourVector3Action.md#LinkedVector3Behaviour
+[LinkedVector3Behaviour]: SteamVRBehaviourVector3Action.md#LinkedVector3Behaviour
+[LinkedVector3Behaviour]: SteamVRBehaviourVector3Action.md#LinkedVector3Behaviour
+[LinkedVector3Behaviour]: SteamVRBehaviourVector3Action.md#LinkedVector3Behaviour
 [Inheritance]: #Inheritance
 [Namespace]: #Namespace
 [Syntax]: #Syntax
+[Properties]: #Properties
+[AxisValue]: #AxisValue
+[LinkedVector3Behaviour]: #LinkedVector3Behaviour
 [Methods]: #Methods
+[ClearLinkedVector3Behaviour()]: #ClearLinkedVector3Behaviour
 [Listener(SteamVR\_Behaviour\_Vector3, SteamVR\_Input\_Sources, Vector3, Vector3)]: #ListenerSteamVR\_Behaviour\_Vector3-SteamVR\_Input\_Sources-Vector3-Vector3
 [OnAfterLinkedVector3BehaviourChange()]: #OnAfterLinkedVector3BehaviourChange
 [OnBeforeLinkedVector3BehaviourChange()]: #OnBeforeLinkedVector3BehaviourChange

--- a/Documentation/API/Tracking/CameraRig.meta
+++ b/Documentation/API/Tracking/CameraRig.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: de62d9b923f24c640b01fde6ea19b418
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/API/Tracking/CameraRig/README.md
+++ b/Documentation/API/Tracking/CameraRig/README.md
@@ -1,0 +1,9 @@
+# Namespace Tilia.SDK.SteamVR.Tracking.CameraRig
+
+### Classes
+
+#### [SteamVRInputSourceRecord]
+
+Provides the description for a SteamVR Input Source element. TODO: This is a very basic implementation that doesn't use any of the SteamVR library and relies on the Unity libraries. It needs updating to use the SteamVR mechanisms where possible.
+
+[SteamVRInputSourceRecord]: SteamVRInputSourceRecord.md

--- a/Documentation/API/Tracking/CameraRig/README.md.meta
+++ b/Documentation/API/Tracking/CameraRig/README.md.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 5f1dc365582efbb4ea914a4122e13938
+guid: c44bbccfceed5b144b4f62b465b9bb91
 TextScriptImporter:
   externalObjects: {}
   userData: 

--- a/Documentation/API/Tracking/CameraRig/SteamVRInputSourceRecord.md
+++ b/Documentation/API/Tracking/CameraRig/SteamVRInputSourceRecord.md
@@ -1,0 +1,114 @@
+# Class SteamVRInputSourceRecord
+
+Provides the description for a SteamVR Input Source element. TODO: This is a very basic implementation that doesn't use any of the SteamVR library and relies on the Unity libraries. It needs updating to use the SteamVR mechanisms where possible.
+
+## Contents
+
+* [Inheritance]
+* [Namespace]
+* [Syntax]
+* [Properties]
+  * [InputSource]
+  * [Priority]
+  * [XRNodeType]
+* [Methods]
+  * [ConvertFromInputSource(SteamVR\_Input\_Sources)]
+  * [SetInputSourceType(Int32)]
+
+## Details
+
+##### Inheritance
+
+* System.Object
+* SteamVRInputSourceRecord
+
+##### Namespace
+
+* [Tilia.SDK.SteamVR.Tracking.CameraRig]
+
+##### Syntax
+
+```
+public class SteamVRInputSourceRecord : BaseDeviceDetailsRecord
+```
+
+### Properties
+
+#### InputSource
+
+The SteamVR Input Source.
+
+##### Declaration
+
+```
+public SteamVR_Input_Sources InputSource { get; set; }
+```
+
+#### Priority
+
+##### Declaration
+
+```
+public override int Priority { get; protected set; }
+```
+
+#### XRNodeType
+
+##### Declaration
+
+```
+public override XRNode XRNodeType { get; protected set; }
+```
+
+### Methods
+
+#### ConvertFromInputSource(SteamVR\_Input\_Sources)
+
+Converts an SteamVR\_Input\_Sources type to a Unity XRNode type.
+
+##### Declaration
+
+```
+protected virtual XRNode ConvertFromInputSource(SteamVR_Input_Sources inputSource)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| SteamVR\_Input\_Sources | inputSource | The input source type to convert. |
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| XRNode | The converted type. |
+
+#### SetInputSourceType(Int32)
+
+Sets the [InputSource].
+
+##### Declaration
+
+```
+public virtual void SetInputSourceType(int index)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Int32 | index | The index of the SteamVR\_Input\_Sources. |
+
+[Tilia.SDK.SteamVR.Tracking.CameraRig]: README.md
+[InputSource]: SteamVRInputSourceRecord.md#InputSource
+[Inheritance]: #Inheritance
+[Namespace]: #Namespace
+[Syntax]: #Syntax
+[Properties]: #Properties
+[InputSource]: #InputSource
+[Priority]: #Priority
+[XRNodeType]: #XRNodeType
+[Methods]: #Methods
+[ConvertFromInputSource(SteamVR\_Input\_Sources)]: #ConvertFromInputSourceSteamVR\_Input\_Sources
+[SetInputSourceType(Int32)]: #SetInputSourceTypeInt32

--- a/Documentation/API/Tracking/CameraRig/SteamVRInputSourceRecord.md.meta
+++ b/Documentation/API/Tracking/CameraRig/SteamVRInputSourceRecord.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c932793eff60bce47ab02758b3b71180
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/FodyWeavers.xml
+++ b/FodyWeavers.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-
-<Weavers>
-  <Malimbe.FodyRunner>
-    <AssemblyNameRegex>^Tilia.SDK.SteamVR</AssemblyNameRegex>
-  </Malimbe.FodyRunner>
-</Weavers>

--- a/Runtime/SharedResources/Scripts/Haptics/SteamVRActionHapticPulser.cs
+++ b/Runtime/SharedResources/Scripts/Haptics/SteamVRActionHapticPulser.cs
@@ -1,7 +1,5 @@
 ﻿namespace Tilia.SDK.SteamVR.Haptics
 {
-    using Malimbe.PropertySerializationAttribute;
-    using Malimbe.XmlDocumentationAttribute;
     using UnityEngine;
     using Valve.VR;
     using Zinnia.Haptics;
@@ -11,36 +9,92 @@
     /// </summary>
     public class SteamVRActionHapticPulser : HapticPulser
     {
+        [Tooltip("The vibration action to activate.")]
+        [SerializeField]
+        private SteamVR_Action_Vibration vibrationAction;
         /// <summary>
         /// The vibration action to activate.
         /// </summary>
-        [Serialized]
-        [field: DocumentedByXml]
-        public SteamVR_Action_Vibration VibrationAction { get; set; }
+        public SteamVR_Action_Vibration VibrationAction
+        {
+            get
+            {
+                return vibrationAction;
+            }
+            set
+            {
+                vibrationAction = value;
+            }
+        }
+        [Tooltip("The controller to pulse.")]
+        [SerializeField]
+        private SteamVR_Input_Sources controller = SteamVR_Input_Sources.Any;
         /// <summary>
         /// The controller to pulse.
         /// </summary>
-        [Serialized]
-        [field: DocumentedByXml]
-        public SteamVR_Input_Sources Controller { get; set; } = SteamVR_Input_Sources.Any;
+        public SteamVR_Input_Sources Controller
+        {
+            get
+            {
+                return controller;
+            }
+            set
+            {
+                controller = value;
+            }
+        }
+        [Tooltip("The duration to pulse Controller for.")]
+        [SerializeField]
+        private float duration = 0.1f;
         /// <summary>
         /// The duration to pulse <see cref="Controller"/> for.
         /// </summary>
-        [Serialized]
-        [field: DocumentedByXml]
-        public float Duration { get; set; } = 0.1f;
+        public float Duration
+        {
+            get
+            {
+                return duration;
+            }
+            set
+            {
+                duration = value;
+            }
+        }
+        [Tooltip("The frequency in which the haptic motor will bounce.")]
+        [SerializeField]
+        [Range(0f, 320f)]
+        private float frequency = 1f;
         /// <summary>
         /// The frequency in which the haptic motor will bounce.
         /// </summary>
-        [Serialized]
-        [field: DocumentedByXml, Range(0f, 320f)]
-        public float Frequency { get; set; } = 1f;
+        public float Frequency
+        {
+            get
+            {
+                return frequency;
+            }
+            set
+            {
+                frequency = value;
+            }
+        }
+        [Tooltip("The duration to wait before starting the pulse.")]
+        [SerializeField]
+        private float startDelay = 0f;
         /// <summary>
         /// The duration to wait before starting the pulse.
         /// </summary>
-        [Serialized]
-        [field: DocumentedByXml]
-        public float StartDelay { get; set; } = 0f;
+        public float StartDelay
+        {
+            get
+            {
+                return startDelay;
+            }
+            set
+            {
+                startDelay = value;
+            }
+        }
 
         /// <inheritdoc />
         protected override void DoBegin()

--- a/Runtime/SharedResources/Scripts/Input/SteamVRBehaviourBooleanAction.cs
+++ b/Runtime/SharedResources/Scripts/Input/SteamVRBehaviourBooleanAction.cs
@@ -1,23 +1,53 @@
 ﻿namespace Tilia.SDK.SteamVR.Input
 {
-    using Malimbe.MemberChangeMethod;
-    using Malimbe.MemberClearanceMethod;
-    using Malimbe.PropertySerializationAttribute;
-    using Malimbe.XmlDocumentationAttribute;
+    using UnityEngine;
     using Valve.VR;
     using Zinnia.Action;
+    using Zinnia.Extension;
 
     /// <summary>
     /// Listens for the linked boolean behavior and emits the appropriate action.
     /// </summary>
     public class SteamVRBehaviourBooleanAction : BooleanAction
     {
+        [Tooltip("The SteamVR Boolean Behavior to link this action to.")]
+        [SerializeField]
+        private SteamVR_Behaviour_Boolean linkedBooleanBehaviour;
         /// <summary>
         /// The SteamVR Boolean Behavior to link this action to.
         /// </summary>
-        [Serialized, Cleared]
-        [field: DocumentedByXml]
-        SteamVR_Behaviour_Boolean LinkedBooleanBehaviour { get; set; }
+        public SteamVR_Behaviour_Boolean LinkedBooleanBehaviour
+        {
+            get
+            {
+                return linkedBooleanBehaviour;
+            }
+            set
+            {
+                if (this.IsMemberChangeAllowed())
+                {
+                    OnBeforeLinkedBooleanBehaviourChange();
+                }
+                linkedBooleanBehaviour = value;
+                if (this.IsMemberChangeAllowed())
+                {
+                    OnAfterLinkedBooleanBehaviourChange();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Clears <see cref="LinkedBooleanBehaviour"/>.
+        /// </summary>
+        public virtual void ClearLinkedBooleanBehaviour()
+        {
+            if (!this.IsValidState())
+            {
+                return;
+            }
+
+            LinkedBooleanBehaviour = default;
+        }
 
         protected override void OnEnable()
         {
@@ -73,7 +103,6 @@
         /// <summary>
         /// Called before <see cref="LinkedBooleanBehaviour"/> has been changed.
         /// </summary>
-        [CalledBeforeChangeOf(nameof(LinkedBooleanBehaviour))]
         protected virtual void OnBeforeLinkedBooleanBehaviourChange()
         {
             UnregisterListeners();
@@ -82,7 +111,6 @@
         /// <summary>
         /// Called after <see cref="LinkedBooleanBehaviour"/> has been changed.
         /// </summary>
-        [CalledAfterChangeOf(nameof(LinkedBooleanBehaviour))]
         protected virtual void OnAfterLinkedBooleanBehaviourChange()
         {
             RegisterListeners();

--- a/Runtime/SharedResources/Scripts/Input/SteamVRBehaviourFloatAction.cs
+++ b/Runtime/SharedResources/Scripts/Input/SteamVRBehaviourFloatAction.cs
@@ -1,11 +1,9 @@
 ﻿namespace Tilia.SDK.SteamVR.Input
 {
-    using Malimbe.MemberChangeMethod;
-    using Malimbe.MemberClearanceMethod;
-    using Malimbe.PropertySerializationAttribute;
-    using Malimbe.XmlDocumentationAttribute;
+    using UnityEngine;
     using Valve.VR;
     using Zinnia.Action;
+    using Zinnia.Extension;
 
     /// <summary>
     /// Listens for the linked single behavior and emits the appropriate action.
@@ -27,18 +25,61 @@
             Delta
         }
 
+        [Tooltip("The SteamVR Single Behavior to link this action to.")]
+        [SerializeField]
+        private SteamVR_Behaviour_Single linkedSingleBehaviour;
         /// <summary>
         /// The SteamVR Single Behavior to link this action to.
         /// </summary>
-        [Serialized, Cleared]
-        [field: DocumentedByXml]
-        SteamVR_Behaviour_Single LinkedSingleBehaviour { get; set; }
+        public SteamVR_Behaviour_Single LinkedSingleBehaviour
+        {
+            get
+            {
+                return linkedSingleBehaviour;
+            }
+            set
+            {
+                if (this.IsMemberChangeAllowed())
+                {
+                    OnBeforeLinkedSingleBehaviourChange();
+                }
+                linkedSingleBehaviour = value;
+                if (this.IsMemberChangeAllowed())
+                {
+                    OnAfterLinkedSingleBehaviourChange();
+                }
+            }
+        }
+        [Tooltip("The value to receive from the axis data.")]
+        [SerializeField]
+        private ValueType axisValue = ValueType.Actual;
         /// <summary>
         /// The value to receive from the axis data.
         /// </summary>
-        [Serialized]
-        [field: DocumentedByXml]
-        ValueType AxisValue { get; set; } = ValueType.Actual;
+        public ValueType AxisValue
+        {
+            get
+            {
+                return axisValue;
+            }
+            set
+            {
+                axisValue = value;
+            }
+        }
+
+        /// <summary>
+        /// Clears <see cref="LinkedSingleBehaviour"/>.
+        /// </summary>
+        public virtual void ClearLinkedSingleBehaviour()
+        {
+            if (!this.IsValidState())
+            {
+                return;
+            }
+
+            LinkedSingleBehaviour = default;
+        }
 
         protected override void OnEnable()
         {
@@ -101,7 +142,6 @@
         /// <summary>
         /// Called before <see cref="LinkedSingleBehaviour"/> has been changed.
         /// </summary>
-        [CalledBeforeChangeOf(nameof(LinkedSingleBehaviour))]
         protected virtual void OnBeforeLinkedSingleBehaviourChange()
         {
             UnregisterListeners();
@@ -110,7 +150,6 @@
         /// <summary>
         /// Called after <see cref="LinkedSingleBehaviour"/> has been changed.
         /// </summary>
-        [CalledAfterChangeOf(nameof(LinkedSingleBehaviour))]
         protected virtual void OnAfterLinkedSingleBehaviourChange()
         {
             RegisterListeners();

--- a/Runtime/SharedResources/Scripts/Input/SteamVRBehaviourVector2Action.cs
+++ b/Runtime/SharedResources/Scripts/Input/SteamVRBehaviourVector2Action.cs
@@ -1,12 +1,9 @@
 ﻿namespace Tilia.SDK.SteamVR.Input
 {
-    using Malimbe.MemberChangeMethod;
-    using Malimbe.MemberClearanceMethod;
-    using Malimbe.PropertySerializationAttribute;
-    using Malimbe.XmlDocumentationAttribute;
     using UnityEngine;
     using Valve.VR;
     using Zinnia.Action;
+    using Zinnia.Extension;
 
     /// <summary>
     /// Listens for the linked <see cref="Vector2"/> behavior and emits the appropriate action.
@@ -28,18 +25,61 @@
             Delta
         }
 
+        [Tooltip("The SteamVR Vector2 Behavior to link this action to.")]
+        [SerializeField]
+        private SteamVR_Behaviour_Vector2 linkedVector2Behaviour;
         /// <summary>
         /// The SteamVR Vector2 Behavior to link this action to.
         /// </summary>
-        [Serialized, Cleared]
-        [field: DocumentedByXml]
-        SteamVR_Behaviour_Vector2 LinkedVector2Behaviour { get; set; }
+        public SteamVR_Behaviour_Vector2 LinkedVector2Behaviour
+        {
+            get
+            {
+                return linkedVector2Behaviour;
+            }
+            set
+            {
+                if (this.IsMemberChangeAllowed())
+                {
+                    OnBeforeLinkedVector2BehaviourChange();
+                }
+                linkedVector2Behaviour = value;
+                if (this.IsMemberChangeAllowed())
+                {
+                    OnAfterLinkedVector2BehaviourChange();
+                }
+            }
+        }
+        [Tooltip("The value to receive from the axis data.")]
+        [SerializeField]
+        private ValueType axisValue = ValueType.Actual;
         /// <summary>
         /// The value to receive from the axis data.
         /// </summary>
-        [Serialized]
-        [field: DocumentedByXml]
-        ValueType AxisValue { get; set; } = ValueType.Actual;
+        public ValueType AxisValue
+        {
+            get
+            {
+                return axisValue;
+            }
+            set
+            {
+                axisValue = value;
+            }
+        }
+
+        /// <summary>
+        /// Clears <see cref="LinkedVector2Behaviour"/>.
+        /// </summary>
+        public virtual void ClearLinkedVector2Behaviour()
+        {
+            if (!this.IsValidState())
+            {
+                return;
+            }
+
+            LinkedVector2Behaviour = default;
+        }
 
         protected override void OnEnable()
         {
@@ -102,7 +142,6 @@
         /// <summary>
         /// Called before <see cref="LinkedVector2Behaviour"/> has been changed.
         /// </summary>
-        [CalledBeforeChangeOf(nameof(LinkedVector2Behaviour))]
         protected virtual void OnBeforeLinkedVector2BehaviourChange()
         {
             UnregisterListeners();
@@ -111,7 +150,6 @@
         /// <summary>
         /// Called after <see cref="LinkedVector2Behaviour"/> has been changed.
         /// </summary>
-        [CalledAfterChangeOf(nameof(LinkedVector2Behaviour))]
         protected virtual void OnAfterLinkedVector2BehaviourChange()
         {
             RegisterListeners();

--- a/Runtime/SharedResources/Scripts/Input/SteamVRBehaviourVector3Action.cs
+++ b/Runtime/SharedResources/Scripts/Input/SteamVRBehaviourVector3Action.cs
@@ -1,12 +1,9 @@
 ﻿namespace Tilia.SDK.SteamVR.Input
 {
-    using Malimbe.MemberChangeMethod;
-    using Malimbe.MemberClearanceMethod;
-    using Malimbe.PropertySerializationAttribute;
-    using Malimbe.XmlDocumentationAttribute;
     using UnityEngine;
     using Valve.VR;
     using Zinnia.Action;
+    using Zinnia.Extension;
 
     /// <summary>
     /// Listens for the linked <see cref="Vector3"/> behavior and emits the appropriate action.
@@ -28,18 +25,61 @@
             Delta
         }
 
+        [Tooltip("The SteamVR Vector3 Behavior to link this action to.")]
+        [SerializeField]
+        private SteamVR_Behaviour_Vector3 linkedVector3Behaviour;
         /// <summary>
         /// The SteamVR Vector3 Behavior to link this action to.
         /// </summary>
-        [Serialized, Cleared]
-        [field: DocumentedByXml]
-        SteamVR_Behaviour_Vector3 LinkedVector3Behaviour { get; set; }
+        public SteamVR_Behaviour_Vector3 LinkedVector3Behaviour
+        {
+            get
+            {
+                return linkedVector3Behaviour;
+            }
+            set
+            {
+                if (this.IsMemberChangeAllowed())
+                {
+                    OnBeforeLinkedVector3BehaviourChange();
+                }
+                linkedVector3Behaviour = value;
+                if (this.IsMemberChangeAllowed())
+                {
+                    OnAfterLinkedVector3BehaviourChange();
+                }
+            }
+        }
+        [Tooltip("The value to receive from the axis data.")]
+        [SerializeField]
+        private ValueType axisValue = ValueType.Actual;
         /// <summary>
         /// The value to receive from the axis data.
         /// </summary>
-        [Serialized]
-        [field: DocumentedByXml]
-        ValueType AxisValue { get; set; } = ValueType.Actual;
+        public ValueType AxisValue
+        {
+            get
+            {
+                return axisValue;
+            }
+            set
+            {
+                axisValue = value;
+            }
+        }
+
+        /// <summary>
+        /// Clears <see cref="LinkedVector3Behaviour"/>.
+        /// </summary>
+        public virtual void ClearLinkedVector3Behaviour()
+        {
+            if (!this.IsValidState())
+            {
+                return;
+            }
+
+            LinkedVector3Behaviour = default;
+        }
 
         protected override void OnEnable()
         {
@@ -102,7 +142,6 @@
         /// <summary>
         /// Called before <see cref="LinkedVector3Behaviour"/> has been changed.
         /// </summary>
-        [CalledBeforeChangeOf(nameof(LinkedVector3Behaviour))]
         protected virtual void OnBeforeLinkedVector3BehaviourChange()
         {
             UnregisterListeners();
@@ -111,7 +150,6 @@
         /// <summary>
         /// Called after <see cref="LinkedVector3Behaviour"/> has been changed.
         /// </summary>
-        [CalledAfterChangeOf(nameof(LinkedVector3Behaviour))]
         protected virtual void OnAfterLinkedVector3BehaviourChange()
         {
             RegisterListeners();

--- a/Runtime/SharedResources/Scripts/Tracking/CameraRig/SteamVRInputSourceRecord.cs
+++ b/Runtime/SharedResources/Scripts/Tracking/CameraRig/SteamVRInputSourceRecord.cs
@@ -1,7 +1,6 @@
 ﻿namespace Tilia.SDK.SteamVR.Tracking.CameraRig
 {
-    using Malimbe.PropertySerializationAttribute;
-    using Malimbe.XmlDocumentationAttribute;
+    using UnityEngine;
     using UnityEngine.XR;
     using Valve.VR;
     using Zinnia.Extension;
@@ -13,12 +12,23 @@
     /// </summary>
     public class SteamVRInputSourceRecord : BaseDeviceDetailsRecord
     {
+        [Tooltip("The SteamVR Input Source.")]
+        [SerializeField]
+        private SteamVR_Input_Sources inputSource;
         /// <summary>
-        /// The SteamVR Input Source
+        /// The SteamVR Input Source.
         /// </summary>
-        [Serialized]
-        [field: DocumentedByXml]
-        public SteamVR_Input_Sources InputSource { get; set; }
+        public SteamVR_Input_Sources InputSource
+        {
+            get
+            {
+                return inputSource;
+            }
+            set
+            {
+                inputSource = value;
+            }
+        }
 
         /// <inheritdoc/>
         public override XRNode XRNodeType { get => ConvertFromInputSource(InputSource); protected set => throw new System.NotImplementedException(); }

--- a/Runtime/SharedResources/Scripts/Tracking/Velocity/SteamVRBehaviourVelocityEstimator.cs
+++ b/Runtime/SharedResources/Scripts/Tracking/Velocity/SteamVRBehaviourVelocityEstimator.cs
@@ -1,7 +1,5 @@
 ﻿namespace Tilia.SDK.SteamVR.Tracking.Velocity
 {
-    using Malimbe.PropertySerializationAttribute;
-    using Malimbe.XmlDocumentationAttribute;
     using UnityEngine;
     using Valve.VR;
     using Zinnia.Tracking.Velocity;
@@ -11,18 +9,40 @@
     /// </summary>
     public class SteamVRBehaviourVelocityEstimator : VelocityTracker
     {
+        [Tooltip("The SteamVR_Behaviour_Pose to track velocity for.")]
+        [SerializeField]
+        private SteamVR_Behaviour_Pose velocitySource;
         /// <summary>
         /// The <see cref="SteamVR_Behaviour_Pose"/> to track velocity for.
         /// </summary>
-        [Serialized]
-        [field: DocumentedByXml]
-        public SteamVR_Behaviour_Pose VelocitySource { get; set; }
+        public SteamVR_Behaviour_Pose VelocitySource
+        {
+            get
+            {
+                return velocitySource;
+            }
+            set
+            {
+                velocitySource = value;
+            }
+        }
+        [Tooltip("An optional GameObject to consider the source relative to when retrieving velocities.")]
+        [SerializeField]
+        private GameObject relativeTo;
         /// <summary>
         /// An optional <see cref="GameObject"/> to consider the source relative to when retrieving velocities.
         /// </summary>
-        [Serialized]
-        [field: DocumentedByXml]
-        public GameObject RelativeTo { get; set; }
+        public GameObject RelativeTo
+        {
+            get
+            {
+                return relativeTo;
+            }
+            set
+            {
+                relativeTo = value;
+            }
+        }
 
         /// <inheritdoc />
         public override bool IsActive()

--- a/Runtime/Tilia.SDK.SteamVR.Unity.Runtime.asmdef
+++ b/Runtime/Tilia.SDK.SteamVR.Unity.Runtime.asmdef
@@ -12,13 +12,7 @@
     ],
     "allowUnsafeCode": false,
     "overrideReferences": true,
-    "precompiledReferences": [
-        "Malimbe.PropertySerializationAttribute.dll",
-        "Malimbe.XmlDocumentationAttribute.dll",
-        "Malimbe.MemberChangeMethod.dll",
-        "Malimbe.MemberClearanceMethod.dll",
-        "Malimbe.BehaviourStateRequirementMethod.dll"
-    ],
+    "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
     "versionDefines": []


### PR DESCRIPTION
BREAKING CHANGE: This removes the last remaining elements of
Malimbe and whilst it does not cause any breaking changes within
this package, it removes Malimbe as a dependency which other projects
that rely on this package may piggy back off this Malimbe dependency
so it will break any project like that.

All of the previous functionality from Malimbe has been replicated in
standard code without the need for it to be weaved by the Malimbe
helper tags.