### PR TITLE
feat(DeviceDetails): add defaults for passthrough camera details

### DIFF
--- a/Documentation/API/Tracking/CameraRig/SteamVRInputSourceRecord.md
+++ b/Documentation/API/Tracking/CameraRig/SteamVRInputSourceRecord.md
@@ -8,6 +8,7 @@ Provides the description for a SteamVR Input Source element. TODO: This is a ver
 * [Namespace]
 * [Syntax]
 * [Properties]
+  * [HasPassThroughCamera]
   * [InputSource]
   * [Priority]
   * [XRNodeType]
@@ -33,6 +34,14 @@ public class SteamVRInputSourceRecord : BaseDeviceDetailsRecord
 ```
 
 ### Properties
+
+#### HasPassThroughCamera
+
+##### Declaration
+
+```
+public override bool HasPassThroughCamera { get; protected set; }
+```
 
 #### InputSource
 
@@ -106,6 +115,7 @@ public virtual void SetInputSourceType(int index)
 [Namespace]: #Namespace
 [Syntax]: #Syntax
 [Properties]: #Properties
+[HasPassThroughCamera]: #HasPassThroughCamera
 [InputSource]: #InputSource
 [Priority]: #Priority
 [XRNodeType]: #XRNodeType

--- a/Runtime/SharedResources/Scripts/Tracking/CameraRig/SteamVRInputSourceRecord.cs
+++ b/Runtime/SharedResources/Scripts/Tracking/CameraRig/SteamVRInputSourceRecord.cs
@@ -34,6 +34,8 @@
         public override XRNode XRNodeType { get => ConvertFromInputSource(InputSource); protected set => throw new System.NotImplementedException(); }
         /// <inheritdoc/>
         public override int Priority { get => 0; protected set => throw new System.NotImplementedException(); }
+        /// <inheritdoc/>
+        public override bool HasPassThroughCamera { get => false; protected set => throw new System.NotImplementedException(); }
 
         /// <summary>
         /// Sets the <see cref="InputSource"/>.

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "url": "https://github.com/ExtendRealityLtd"
     },
     "dependencies": {
-        "io.extendreality.zinnia.unity": "2.6.0"
+        "io.extendreality.zinnia.unity": "2.7.0"
     },
     "files": [
         "*.md",


### PR DESCRIPTION
The DeviceDetailsRecord now supports passthrough camera options and therefore anything that derrives from that needs to implement the base interfaces even if they don't support camera passthrough yet.